### PR TITLE
REM-2 이슈 처리

### DIFF
--- a/Assets/Scripts/Combat/Projectile.cs
+++ b/Assets/Scripts/Combat/Projectile.cs
@@ -21,7 +21,7 @@ namespace RPG.Combat
         void Update()
         {
             if (target == null) return;
-            if (isHoming)
+            if (isHoming && target.IsDead())
             {
                 transform.LookAt(GetAimLocation());
             }


### PR DESCRIPTION
- 화살 투사체가 타겟 한 몬스터가 사망할 경우 그 몬스터를 향해 가지 않고 직선 이동하도록 수정